### PR TITLE
Fix bugs and improve code safety in msgcollector utilities

### DIFF
--- a/usr/libexec/msgcollector/alert
+++ b/usr/libexec/msgcollector/alert
@@ -108,7 +108,7 @@ def main():
 
     args = parser.parse_args()
 
-    if not args.filename and args.section:
+    if not args.filename or not args.section:
         parser.usage()
         sys.exit(1)
 

--- a/usr/libexec/msgcollector/alert
+++ b/usr/libexec/msgcollector/alert
@@ -60,7 +60,7 @@ class Messages():
 
                 self.icon = section.get('icon', None)
 
-                language = section.get(self.language, DEFAULT_LANG)
+                language = section.get(self.language, section.get(DEFAULT_LANG, {}))
 
                 self.title = language.get('title', None)
                 self.message = language.get('message', None)

--- a/usr/libexec/msgcollector/error_handler
+++ b/usr/libexec/msgcollector/error_handler
@@ -69,10 +69,10 @@ $error_text"
       if [ "$TITLE" = "" ]; then
          TITLE="No TITLE defined yet."
       fi
-      $output_x ${output_opts[@]} --titlex "$TITLE"
-      $output_cli ${output_opts[@]} --titlecli "$TITLE"
-      $output_x ${output_opts[@]} --messagex --typex "error" --message "$MSG"
-      $output_cli ${output_opts[@]} --messagecli --typecli "error" --message "$MSG"
+      $output_x "${output_opts[@]}" --titlex "$TITLE"
+      $output_cli "${output_opts[@]}" --titlecli "$TITLE"
+      $output_x "${output_opts[@]}" --messagex --typex "error" --message "$MSG"
+      $output_cli "${output_opts[@]}" --messagecli --typecli "error" --message "$MSG"
    else
       local stripped_msg
       stripped_msg="$(sanitize-string -- nolimit "$MSG")"

--- a/usr/libexec/msgcollector/msgcollector
+++ b/usr/libexec/msgcollector/msgcollector
@@ -99,7 +99,7 @@ parse_cmd_options() {
    ## Thanks to:
    ## http://mywiki.wooledge.org/BashFAQ/035
 
-   true "${cyan}INFO:${cyan} parse_cmd_options msgcollector"
+   true "${cyan}INFO:${reset} parse_cmd_options msgcollector"
 
    while true; do
        case $1 in
@@ -791,8 +791,8 @@ forget() {
       "${msgcollector_run_dir}/${identifier}_${progressbaridx}_progressbartitlex"
       "${msgcollector_run_dir}/${identifier}_typecli"
       "${msgcollector_run_dir}/${identifier}_typex"
-      "${msgcollector_run_dir}/${identifier}_progressbarx_done"
-      "${msgcollector_run_dir}/${identifier}_progressbarx"
+      "${msgcollector_run_dir}/${identifier}_${progressbaridx}_progressbarx_done"
+      "${msgcollector_run_dir}/${identifier}_${progressbaridx}_progressbarx"
       "${msgcollector_run_dir}/${identifier}_passivepopupqueuex_done"
       "${msgcollector_run_dir}/${identifier}_passivepopupqueuex"
       "${msgcollector_run_dir}/${identifier}_messagex_done"
@@ -832,10 +832,10 @@ forgetwaitcli() {
    local file_name
    for file_name in "${file_list[@]}"; do
       if [ -e "$file_name" ]; then
-         safe-rm --force "$file_name"
+         safe-rm --force -- "$file_name"
       fi
    done
-   unset local file_name
+   unset file_name
 }
 
 ## Debugging.

--- a/usr/libexec/msgcollector/msgcollector
+++ b/usr/libexec/msgcollector/msgcollector
@@ -218,7 +218,7 @@ parse_cmd_options() {
                shift
                ;;
            --animate)
-               animate="1"
+               animate="--animate"
                shift
                ;;
            --nonewlinex)
@@ -570,7 +570,7 @@ collector() {
    ## }}
 
    ## {{ --animate
-   if [ "$animate" = "1" ]; then
+   if [ "$animate" = "--animate" ]; then
       touch -- "${msgcollector_run_dir}/${identifier}_${progressbaridx}_progressbarx_animate"
    fi
    ## }}

--- a/usr/libexec/msgcollector/msgdispatcher
+++ b/usr/libexec/msgcollector/msgdispatcher
@@ -204,11 +204,11 @@ dispatch_x_active() {
    fi
 
    if [ "$verbose" = "1" ]; then
-      /usr/libexec/msgcollector/msgdispatcher_dispatch_x "$type" "$title" "$msg" "$icon"
+      /usr/libexec/msgcollector/msgdispatcher_dispatch_x "$type" "$title" "$msg" "0" "$icon"
    else
       ## Launching into background, so it doesn't block msgdispatcher until
       ## msgdispatcher_dispatch_x exits.
-      /usr/libexec/msgcollector/msgdispatcher_dispatch_x "$type" "$title" "$msg" "$icon" &
+      /usr/libexec/msgcollector/msgdispatcher_dispatch_x "$type" "$title" "$msg" "0" "$icon" &
    fi
 }
 

--- a/usr/libexec/msgcollector/msgdispatcher
+++ b/usr/libexec/msgcollector/msgdispatcher
@@ -335,6 +335,7 @@ msgdispatcher_handler() {
             dispatch_cli "$msg"
             msgdispatcher_delete_wrapper "waitmessagecli_done"
             msgdispatcher_delete_wrapper "waitmessagecli"
+            msgdispatcher_delete_wrapper "typecli"
          else
             true "INFO: waitmessagecli file does NOT exist."
             msgdispatcher_delete_wrapper "waitmessagecli_done"
@@ -349,6 +350,7 @@ msgdispatcher_handler() {
             dispatch_cli "$msg"
             msgdispatcher_delete_wrapper "messagecli_done"
             msgdispatcher_delete_wrapper "messagecli"
+            msgdispatcher_delete_wrapper "typecli"
          else
             msgdispatcher_delete_wrapper "messagecli_done"
          fi

--- a/usr/libexec/msgcollector/msgdispatcher
+++ b/usr/libexec/msgcollector/msgdispatcher
@@ -11,6 +11,7 @@ set -o errtrace
 
 error_handler() {
    local last_exit_code="$?"
+   trap - ERR
    if [ ! "$1" = "" ]; then
       error_text="$1"
    else

--- a/usr/libexec/msgcollector/msgdispatcher_run_check
+++ b/usr/libexec/msgcollector/msgdispatcher_run_check
@@ -181,7 +181,7 @@ output_func() {
       (( cut_start_idx = msg_idx + 1 )) || true
    done
 
-   if (( loop_idx == ( max_loop_count - 1 ) )); then
+   if (( loop_idx >= max_loop_count )); then
       1>&2 printf '%s\n' "output_func: Possible infinite loop hit!"
       return 1
    fi

--- a/usr/libexec/msgcollector/msgdispatcher_run_check
+++ b/usr/libexec/msgcollector/msgdispatcher_run_check
@@ -145,7 +145,7 @@ output_func() {
          ## aren't removing 1 from ${#message_str} here.
          (( msg_idx = ${#message_str} )) || true
 
-         if [ "${message_str:msg_idx:1}" = $'\n' ]; then
+         if [ "${message_str:msg_idx-1:1}" = $'\n' ]; then
            ## OK, but if the last character is a newline we actually do want
            ## to leave that off.
            (( msg_idx-- )) || true

--- a/usr/libexec/msgcollector/msgprogress
+++ b/usr/libexec/msgcollector/msgprogress
@@ -89,7 +89,8 @@ progress_bar() {
       true "did already echo to progress_txt_file"
    else
       did_echo="1"
-      timeout 1 /bin/bash -c 'echo "$1"' -- "$progress" > "$progress_txt_file" || true
+      ## Use printf with positional arg to avoid shell injection via $progress.
+      timeout 1 /bin/bash -c 'printf "%s\n" "$1"' -- "$progress" > "$progress_txt_file" || true
    fi
 
    if [ -p "${msgcollector_run_dir}/${identifier}_${progressbaridx}_fifo" ]; then
@@ -103,7 +104,8 @@ progress_bar() {
             true "yad is running."
             ## For extra security against freezing while trying to write to a non-existing pipe, let's use timeout.
             ## || true to catch an error if the pipe no longer exists.
-            timeout 1 /bin/bash -c 'echo "$1"' -- "$progress" > "$fifo" || true
+            ## Use printf with positional arg to avoid shell injection via $progress.
+            timeout 1 /bin/bash -c 'printf "%s\n" "$1"' -- "$progress" > "$fifo" || true
             ## Debugging.
             #caller="$(ps -p $PPID)" || true
             #echo "progress: $progress | caller: $PPID | $caller" >> /home/user/progresslog

--- a/usr/libexec/msgcollector/msgprogress
+++ b/usr/libexec/msgcollector/msgprogress
@@ -89,7 +89,7 @@ progress_bar() {
       true "did already echo to progress_txt_file"
    else
       did_echo="1"
-      timeout 1 /bin/bash -c "echo $progress" > "$progress_txt_file" || true
+      timeout 1 /bin/bash -c 'echo "$1"' -- "$progress" > "$progress_txt_file" || true
    fi
 
    if [ -p "${msgcollector_run_dir}/${identifier}_${progressbaridx}_fifo" ]; then
@@ -103,7 +103,7 @@ progress_bar() {
             true "yad is running."
             ## For extra security against freezing while trying to write to a non-existing pipe, let's use timeout.
             ## || true to catch an error if the pipe no longer exists.
-            timeout 1 /bin/bash -c "echo $progress" > "$fifo" || true
+            timeout 1 /bin/bash -c 'echo "$1"' -- "$progress" > "$fifo" || true
             ## Debugging.
             #caller="$(ps -p $PPID)" || true
             #echo "progress: $progress | caller: $PPID | $caller" >> /home/user/progresslog

--- a/usr/libexec/msgcollector/msgprogressbar
+++ b/usr/libexec/msgcollector/msgprogressbar
@@ -210,9 +210,9 @@ start_progress_bar() {
    fi
 
    ## Clean up eventual old progress bar.
-   "${timeout_command[@]}" safe-rm --force "$fifo"
+   "${timeout_command[@]}" safe-rm --force -- "$fifo"
 
-   "${timeout_command[@]}" mkfifo "$fifo"
+   "${timeout_command[@]}" mkfifo -- "$fifo"
 
    ## sanity test
    test -p "$fifo"

--- a/usr/libexec/msgcollector/tb_updater_gui
+++ b/usr/libexec/msgcollector/tb_updater_gui
@@ -90,7 +90,7 @@ class GuiMessage(QtWidgets.QDialog):
         self.i_label.setPixmap(QPixmap.fromImage(image))
         self.i_label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         self.label.setText('<p><b>Download confirmation</b></p>\
-                            </p>Currently installed version: <code>%s</code> <p/>' % self.installed_version)
+                            <p>Currently installed version: <code>%s</code></p>' % self.installed_version)
         self.label.setAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         self.label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
 


### PR DESCRIPTION
## Summary
This PR addresses multiple bug fixes and code safety improvements across the msgcollector utility scripts, including proper variable handling, command-line argument parsing, and shell quoting for security.

## Key Changes

- **msgcollector**: 
  - Fixed color code in INFO message (changed `${cyan}` to `${reset}` for proper formatting)
  - Changed `animate` variable to store `"--animate"` instead of `"1"` for consistency
  - Fixed progress bar cleanup in `forget()` function to use `${progressbaridx}` variable, preventing cleanup of wrong files
  - Added `--` separator to `safe-rm` command for safety with filenames starting with dashes
  - Fixed `unset` command to not declare `local` keyword (syntax error)

- **msgdispatcher**:
  - Added missing `"0"` parameter to `msgdispatcher_dispatch_x` function calls
  - Added cleanup of `typecli` file after processing `waitmessagecli` and `messagecli` messages

- **alert**:
  - Fixed language fallback logic to properly handle missing language sections with nested `section.get()` call
  - Fixed argument validation logic from `and` to `or` to properly require both filename and section arguments

- **msgdispatcher_run_check**:
  - Fixed off-by-one error in string indexing: changed `msg_idx:1` to `msg_idx-1:1` to correctly check last character
  - Fixed infinite loop detection condition from `==` to `>=` for proper boundary checking

- **msgprogress**:
  - Improved shell quoting in `timeout` commands by using single quotes and `--` separator to safely handle variable expansion

- **msgprogressbar**:
  - Added `--` separator to `safe-rm` and `mkfifo` commands for improved safety with special filenames

## Notable Implementation Details
These changes primarily focus on defensive programming practices (using `--` separators), fixing variable scope issues, and correcting logical errors in conditionals and string operations.

https://claude.ai/code/session_012UqDLwUdSBFFAoBeQxqobW